### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 8eccea7e0abbe1a47d34e563f64812a6df83b6fc
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 7db1fa4d63f08ca30d334255469144bdbc246673
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack (>= 5.0.0.1)
       activesupport (>= 5.0.0)
       aws-sdk (~> 2.11, >= 2.11.45)
@@ -98,7 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  gobierto_data!
+  gobierto_budgets_data!
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ETL scripts for Gobierto DiBa site
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/lib/gobierto_budgets/budget_data_decorator.rb
+++ b/lib/gobierto_budgets/budget_data_decorator.rb
@@ -3,15 +3,15 @@
 class BudgetDataDecorator < BaseDecorator
   CODE_REGEXP = /(?<lv1>\A.)(?<lv2>.)(?<lv3>.)(?<lv4>..\z)/
   INDEXES_MAP = {
-    ::GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST => %w(ci),
-    ::GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED => %w(cf),
-    ::GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED => %w(o dr)
+    ::GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST => %w[ci],
+    ::GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED => %w[cf],
+    ::GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED => %w[o dr]
   }.freeze
 
   def self.detect_kind(kind_name)
     {
-      "Ingressos" => ::GobiertoData::GobiertoBudgets::INCOME,
-      "Despeses" => ::GobiertoData::GobiertoBudgets::EXPENSE
+      'Ingressos' => ::GobiertoBudgetsData::GobiertoBudgets::INCOME,
+      'Despeses' => ::GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     }[kind_name]
   end
 

--- a/operations/gobierto_budgets/clear-previous-providers/run.rb
+++ b/operations/gobierto_budgets/clear-previous-providers/run.rb
@@ -19,8 +19,8 @@ if ARGV.length != 1
   raise "At least one argument is required"
 end
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_INVOICES
-type =  GobiertoData::GobiertoBudgets::INVOICE_TYPE
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_INVOICES
+type =  GobiertoBudgetsData::GobiertoBudgets::INVOICE_TYPE
 organization_id = ARGV[0].to_s
 
 puts "[START] clear-previous-providers/run.rb organization_id=#{organization_id}"
@@ -43,14 +43,14 @@ query = {
 }
 
 count = 0
-response = GobiertoData::GobiertoBudgets::SearchEngineWriting.client.search index: index, type: type, body: query
+response = GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.search index: index, type: type, body: query
 while response['hits']['total'] > 0
   delete_request_body = response['hits']['hits'].map do |h|
     count += 1
     { delete: h.slice("_index", "_type", "_id") }
   end
-  GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
-  response = GobiertoData::GobiertoBudgets::SearchEngineWriting.client.search index: index, type: type, body: query
+  GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
+  response = GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.search index: index, type: type, body: query
 end
 
 puts "[END] clear-previous-providers/run.rb. Deleted #{count} items"

--- a/operations/gobierto_budgets/import-budgets/run.rb
+++ b/operations/gobierto_budgets/import-budgets/run.rb
@@ -45,12 +45,12 @@ module Diba
 
     def import!
       areas = [GobiertoBudgets::EconomicArea]
-      areas << GobiertoBudgets::FunctionalArea if @data.kind == GobiertoData::GobiertoBudgets::EXPENSE
+      areas << GobiertoBudgets::FunctionalArea if @data.kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 
       indices = [
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST,
-        GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED,
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST,
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED,
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
       ]
 
       total_results = []
@@ -62,8 +62,8 @@ module Diba
           total_results = total_results + result
         end
 
-        if @data.kind == GobiertoData::GobiertoBudgets::EXPENSE
-          index = GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+        if @data.kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
+          index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
           if (partition_result = @data.economic_partitions_for(area, index))
             # Remove levels > 3
             partition_result.delete_if{ |i| i[:index][:data][:level] > 3 }
@@ -77,8 +77,8 @@ module Diba
       total_results = total_results.uniq
       uniq_total_count = total_results.count
 
-      GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk( body: total_results.uniq)
-      puts "=== Loaded #{ total_results.count } entries. #{ total_count - uniq_total_count } duplicated."
+      GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: total_results.uniq)
+      puts "=== Loaded #{total_results.count} entries. #{total_count - uniq_total_count} duplicated."
     end
   end
 end


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`