### PR TITLE
Use clear-cache operation including site and namespace

### DIFF
--- a/Pipeline-budgets-dev.sh
+++ b/Pipeline-budgets-dev.sh
@@ -69,4 +69,4 @@ cd $DEV/gobierto/; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto_
 cd $DEV/gobierto/; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb budgets_updated /tmp/diba/organization_id.txt
 
 # Load > Clear cache
-cd $DEV/gobierto/; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb
+cd $DEV/gobierto/; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-organization-id "diba" --namespace "GobiertoBudgets"

--- a/Pipeline-budgets-prod.sh
+++ b/Pipeline-budgets-prod.sh
@@ -68,4 +68,4 @@ cd $DEV/gobierto/current/; bin/rails runner $DEV/gobierto-etl-utils/current/oper
 cd $DEV/gobierto/current/; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/publish-activity/run.rb budgets_updated /tmp/diba/organization_id.txt
 
 # Load > Clear cache
-cd $DEV/gobierto/current/; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/clear-cache/run.rb
+cd $DEV/gobierto/current/; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/clear-cache/run.rb --site-organization-id "diba" --namespace "GobiertoBudgets"

--- a/Pipeline-providers-dev.sh
+++ b/Pipeline-providers-dev.sh
@@ -34,4 +34,4 @@ echo "diba" > /tmp/diba/organization_id.txt
 cd $DEV/gobierto; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb providers_updated /tmp/diba/organization_id.txt
 
 # Load > Clear cache
-cd $DEV/gobierto; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb
+cd $DEV/gobierto; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-organization-id "diba" --namespace "GobiertoBudgets"

--- a/Pipeline-providers-prod.sh
+++ b/Pipeline-providers-prod.sh
@@ -36,4 +36,4 @@ echo "diba" > /tmp/diba/organization_id.txt
 cd $DEV/gobierto/current; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/publish-activity/run.rb providers_updated /tmp/diba/organization_id.txt
 
 # Load > Clear cache
-cd $DEV/gobierto/current; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/clear-cache/run.rb
+cd $DEV/gobierto/current; bin/rails runner $DEV/gobierto-etl-utils/current/operations/gobierto/clear-cache/run.rb --site-organization-id "diba" --namespace "GobiertoBudgets"


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR replaces the clear-cache operation call and includes site and namespace arguments